### PR TITLE
feat: support to yank link

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ The simple idea behind this plugin is to:
     by running this example command on the terminal : `echo "Hello world" | ssh snips.sh`
     Then you can open your nvim.
 - Select a bunch of lines from your current buffer.
-- Hit `SnipCreate` and you have generated/saved a snippet of your code, you're left with the link to share.
+- Hit `SnipsCreate` and you have generated/saved a snippet of your code, you're left with the link to share.
+
+## DEFAULT OPTIONS
+
+```lua
+local opts = {
+  post_behavior = "echo",  -- or "yank"
+}
+require("snips.nvim").setup(opts)
+```
 
 ## NOTE
 

--- a/lua/snips.lua
+++ b/lua/snips.lua
@@ -49,7 +49,7 @@ end
 
 ---Extract the url from snips.sh output
 function M.yank_shared_url(cleaned_output)
-  local id = cleaned_output:match("id:%s*(%w+)")
+  local id = cleaned_output:match("id:%s*(%S+)")
   if id then
     local url = string.format("https://snips.sh/f/%s", id)
     vim.fn.setreg("+", url)

--- a/lua/snips.lua
+++ b/lua/snips.lua
@@ -49,11 +49,10 @@ end
 
 ---Extract the url from snips.sh output
 function M.yank_shared_url(cleaned_output)
-  -- Extract the URL from the output (kind of salty... idc as soon as it works)
-  -- commenting this because at the end, am not quite sure we need to extract
-  -- the url, the user would also want to see the whole command output, idk?
-  local url = cleaned_output:match("URL 🔗%s+(%S+)")
-  if url then
+  local id = cleaned_output:match("id:%s*(%w+)")
+  if id then
+    local url = string.format("https://snips.sh/f/%s", id)
+    vim.fn.setreg("+", url)
     print("SNIPS URL: " .. url)
   else
     print(cleaned_output)


### PR DESCRIPTION
Close #4 

Add an option to control the behavior after got output from snips.sh.

e.g.

```lua
require("snips.nvim").setup({
  post_behavior = "yank",  -- default: echo
})
```

Bonus

```lua
  --- lazy.nvim
  {
    "Sanix-Darker/snips.nvim",
    cmd = {
      "SnipsCreate",
    },
    opts = {
      post_behavior = "yank",
    },
    keys = {
      { "<leader>S", ":SnipsCreate<cr>", mode = { "v" }, desc = "Share selected code", silent = true },
    },
  },
```