### PR TITLE
feat: support to customize the cmd path and args

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,10 +62,8 @@ The simple idea behind this plugin is to:
 ```lua
 local opts = {
   post_behavior = "echo",  -- or "yank"
-  cat_path = "cat",
-  cat_args = nil,
-  ssh_path = "ssh",
-  ssh_args = nil,
+  cat_cmd = "cat", -- can be bat or less
+  ssh_cmd = "ssh", -- choose your custom ssh client
 }
 require("snips.nvim").setup(opts)
 ```

--- a/README.md
+++ b/README.md
@@ -62,6 +62,10 @@ The simple idea behind this plugin is to:
 ```lua
 local opts = {
   post_behavior = "echo",  -- or "yank"
+  cat_path = "cat",
+  cat_args = nil,
+  ssh_path = "ssh",
+  ssh_args = nil,
 }
 require("snips.nvim").setup(opts)
 ```

--- a/README.md
+++ b/README.md
@@ -55,7 +55,16 @@ The simple idea behind this plugin is to:
     by running this example command on the terminal : `echo "Hello world" | ssh snips.sh`
     Then you can open your nvim.
 - Select a bunch of lines from your current buffer.
-- Hit `SnipCreate` and you have generated/saved a snippet of your code, you're left with the link to share.
+- Hit `SnipsCreate` and you have generated/saved a snippet of your code, you're left with the link to share.
+
+## DEFAULT OPTIONS
+
+```lua
+local opts = {
+  post_behavior = "echo",  -- or "yank"
+}
+require("snips.nvim").setup(opts)
+```
 
 ## NOTE
 

--- a/lua/snips.lua
+++ b/lua/snips.lua
@@ -61,9 +61,9 @@ end
 
 
 ---Execute the ssh command line to send the file on snips
-function M:execute_snips_command()
+function M.execute_snips_command()
     local selected_lines = {}
-    for _, line in ipairs(self.get_selected_lines()) do
+    for _, line in ipairs(M.get_selected_lines()) do
       table.insert(selected_lines, line)
     end
 
@@ -74,7 +74,7 @@ function M:execute_snips_command()
 
     local content = table.concat(selected_lines, "\n")
 
-    local temp_file = os.tmpname() .. "." .. self.get_file_extension()
+    local temp_file = os.tmpname() .. "." .. M.get_file_extension()
     local file = io.open(temp_file, "w")
 
     -- because i miss the simplicity of golang
@@ -97,11 +97,11 @@ function M:execute_snips_command()
     -- to remove fancy colorisations
     local cleaned_output = output:gsub("\27%[[%d;]+m", "")
 
-    if self.opts.post_behavior == "echo" then
+    if M.opts.post_behavior == "echo" then
       -- Create a new empty buffer and paste the output of the code there
-      self.split_and_insert(cleaned_output)
+      M.split_and_insert(cleaned_output)
     else
-      self.yank_shared_url(cleaned_output)
+      M.yank_shared_url(cleaned_output)
     end
 
     -- we erase the tmp file

--- a/lua/snips.lua
+++ b/lua/snips.lua
@@ -49,7 +49,7 @@ end
 
 ---Extract the url from snips.sh output
 function M.yank_shared_url(cleaned_output)
-  local id = cleaned_output:match("id:%s*(%w+)")
+  local id = cleaned_output:match("id:%s*(%S+)")
   if id then
     local url = string.format("https://snips.sh/f/%s", id)
     vim.fn.setreg("+", url)

--- a/lua/snips.lua
+++ b/lua/snips.lua
@@ -53,9 +53,9 @@ function M.yank_shared_url(cleaned_output)
   if id then
     local url = string.format("https://snips.sh/f/%s", id)
     vim.fn.setreg("+", url)
-    print("SNIPS URL: " .. url)
+    vim.print("SNIPS URL: " .. url)
   else
-    print(cleaned_output)
+    vim.print(cleaned_output)
   end
 end
 
@@ -93,7 +93,6 @@ function M.execute_snips_command()
 
     -- yes... you should have at leas "cat " on your system... easy
     local command = M:command_factory(temp_file)
-    print("SNIPS sharing...")
     local output = io.popen(command):read("*a")
     -- to remove fancy colorisations
     local cleaned_output = output:gsub("\27%[[%d;]+m", "")

--- a/lua/snips.lua
+++ b/lua/snips.lua
@@ -49,11 +49,10 @@ end
 
 ---Extract the url from snips.sh output
 function M.yank_shared_url(cleaned_output)
-  -- Extract the URL from the output (kind of salty... idc as soon as it works)
-  -- commenting this because at the end, am not quite sure we need to extract
-  -- the url, the user would also want to see the whole command output, idk?
-  local url = cleaned_output:match("URL 🔗%s+(%S+)")
-  if url then
+  local id = cleaned_output:match("id:%s*(%w+)")
+  if id then
+    local url = string.format("https://snips.sh/f/%s", id)
+    vim.fn.setreg("+", url)
     print("SNIPS URL: " .. url)
   else
     print(cleaned_output)

--- a/lua/snips.lua
+++ b/lua/snips.lua
@@ -93,6 +93,7 @@ function M.execute_snips_command()
 
     -- yes... you should have at leas "cat " on your system... easy
     local command = M:command_factory(temp_file)
+    print("SNIPS sharing...")
     local output = io.popen(command):read("*a")
     -- to remove fancy colorisations
     local cleaned_output = output:gsub("\27%[[%d;]+m", "")

--- a/lua/snips.lua
+++ b/lua/snips.lua
@@ -92,8 +92,8 @@ function M.execute_snips_command()
     end
 
     -- yes... you should have at leas "cat " on your system... easy
-    local ssh_command = string.format("cat %s | ssh snips.sh", temp_file)
-    local output = io.popen(ssh_command):read("*a")
+    local command = M:command_factory(temp_file)
+    local output = io.popen(command):read("*a")
     -- to remove fancy colorisations
     local cleaned_output = output:gsub("\27%[[%d;]+m", "")
 
@@ -110,17 +110,7 @@ end
 
 
 function M:command_factory(file_path)
-  local concat_cmd = function (cmd_path, cmd_args)
-    local cmd = cmd_path
-    if cmd_args ~= nil then
-      cmd = cmd .. table.concat(cmd_args, " ")
-    end
-    return cmd
-  end
-
-  local cat_command = concat_cmd(self.opts.cat_path, self.opts.cat_args)
-  local ssh_command = concat_cmd(self.opts.ssh_path, self.opts.ssh_args)
-  return string.format("%s %s | %s snips.sh", cat_command, file_path, ssh_command)
+  return string.format("%s %s | %s snips.sh", self.opts.cat_cmd, file_path, self.opts.ssh_cmd)
 end
 
 
@@ -129,10 +119,8 @@ function M.setup(opts)
     -- nothing defined yet
     local default_opts = {
       post_behavior = "echo",  -- or "yank"
-      cat_path = "cat",
-      cat_args = nil,
-      ssh_path = "ssh",
-      ssh_args = nil,
+      cat_cmd = "cat",
+      ssh_cmd = "ssh",
     }
     M.opts = vim.tbl_extend("keep", opts, default_opts)
 end


### PR DESCRIPTION
Close #6 

```lua
local opts = {
  post_behavior = "echo",  -- or "yank"
  cat_cmd = "cat",
  ssh_cmd = "ssh",
}
require("snips.nvim").setup(opts)
```